### PR TITLE
add support to build cms9639 rom identical to the real one.

### DIFF
--- a/os9software/build.xml
+++ b/os9software/build.xml
@@ -213,6 +213,7 @@
     <target name="cms9639" depends="prepare">
         <assemble src="OS9p1_ed12" home="cms9639"  verify="c62663295a8df03e8d370e1f2c9c2eb1"/>
         <assemble src="Boot" home="cms9639"  verify="921665455cf8e35d2e966368706e72f8"/>
+        <assemble src="9639_OS92.rom" home="cms9639" verify="5529810dedff592bceba4ddf662fbed5"/>
     </target>
 
     <!-- Positron 9000 -->

--- a/os9software/cms9639/9639_OS92.rom.asm
+++ b/os9software/cms9639/9639_OS92.rom.asm
@@ -1,0 +1,13 @@
+ nam 9639-OS92  V1.2
+*    (c) 1982 MICROWARE CORP.
+*    3975A            [U26]
+*    3A109007-18   1.00/850717
+*    [handwritten] 4.01 10-18-85
+
+ use Boot.asm
+ 
+ fdb $ffff,$ffff,$ffff,$ffff
+ fdb $ffff,$ffff,$ffff,$ffff,$ffff,$ffff,$ffff,$ffff,$ffff,$ffff,$ffff,$ffff
+ fdb $ffff,$ffff,$ffff,$ffff,$ffff,$ffff,$ffff,$ffff,$ffff,$ffff,$ffff,$ffff
+
+ use OS9p1_ed12.asm


### PR DESCRIPTION
This builds a binary that is identical to the upper 4K of the cms9639 rom as delivered by CMS.